### PR TITLE
Add GitHub Skills activity to signup page

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing **GitHub Skills** activity that was announced by the principal but wasn't available on the signup page.

## Changes
- Added "GitHub Skills" activity to the extracurricular activities list
- Includes description highlighting GitHub Certifications program and college application benefits
- Set capacity to 25 students to meet expected high demand
- Activity is now ready for immediate student registration

## Related Issue
Fixes #6 - 🚨 Missing Activity: GitHub Skills

## Details
- **Schedule**: Mondays and Thursdays, 3:30 PM - 4:30 PM
- **Capacity**: 25 students
- **Description**: "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications."

## Testing
- ✅ Python code compiles without errors
- ✅ Activity structure matches existing activities format
- ✅ Ready for students to sign up before the end-of-week deadline

## Priority
⏰ **Time-sensitive**: Registration deadline is end of this week as mentioned in the issue.